### PR TITLE
Underpass map file validation fix

### DIFF
--- a/lib/manageMapFiles.js
+++ b/lib/manageMapFiles.js
@@ -51,7 +51,7 @@ const appBackupPath = path.join(AppData, underpassPreservationName);
 
 const isValidUnderpass = (mapPath) => {
   const { size: fileSize } = fs.statSync(mapPath);
-  if (fileSize >= 2438000 || fileSize <= 2104605) return false;
+  if (fileSize >= 2440000 || fileSize <= 2104605) return false;
   return true;
 };
 


### PR DESCRIPTION
In the latest versions of Rocket League, the original underpass map file exceeds the file size boundaries set in the 'isValidUnderpass' lambda function in the manageMapFile.js file, causing the application to throw an error every time a map is loaded. This change increases the boundaries so that this error isn't triggered and the maps can be loaded again.

I'm not entirely sure why this file size check is performed in the first place but I suspect it will continue to be problematic as the underpass map file increases in size with each new version of Rocket League, so maybe removing the check would be better?

I've tested my fix and it works and solved my problem so it will definitely be able to help others too.