### PR TITLE
Update customMaps.js and manageMapFiles.js

### DIFF
--- a/lib/customMaps.js
+++ b/lib/customMaps.js
@@ -14,15 +14,18 @@ const buildMapObject = (mapDirectory) => (name, index) => {
   const directoryContents = fs.readdirSync(`${mapDirectory}/${name}`);
   const image = makeImagePath(directoryContents, name, mapDirectory);
   const file = directoryContents.find((itemName) => (itemName.includes('.udk') || itemName.includes('.upk')));
+  let metaData;
   try {
-      const metaData = (fs.existsSync(`${mapDirectory}/${name}/info.json`))
-        ? JSON.parse(fs.readFileSync(`${mapDirectory}/${name}/info.json`))
-        : { author: null, desc: null };
+    metaData = (fs.existsSync(`${mapDirectory}/${name}/info.json`))
+      ? JSON.parse(fs.readFileSync(`${mapDirectory}/${name}/info.json`))
+      : { author: null, desc: null };
   } catch (error) {
     // hacky fix attempt at fixing the extremely common problem of "Error invoking remote method 'updatemapsfromdirectory: syntax error: Unexpected string in JSON at position 43" because leth forgot how to json with the Aerial Training Remastered map and blatantly ignored users telling him about it.
     // that error results in the map loader being softlocked until the user figures out that it's because of aerial training remastered and gets rid of it.
+    // take two!
     console.log("whatever we messed up reading the json of this map give it all null!!!");
-    const metaData = { author: null, desc: null};
+    console.error(error)
+    metaData = { author: null, desc: null};
   }
   const { author, desc } = metaData;
   return {

--- a/lib/customMaps.js
+++ b/lib/customMaps.js
@@ -14,9 +14,16 @@ const buildMapObject = (mapDirectory) => (name, index) => {
   const directoryContents = fs.readdirSync(`${mapDirectory}/${name}`);
   const image = makeImagePath(directoryContents, name, mapDirectory);
   const file = directoryContents.find((itemName) => (itemName.includes('.udk') || itemName.includes('.upk')));
-  const metaData = (fs.existsSync(`${mapDirectory}/${name}/info.json`))
-    ? JSON.parse(fs.readFileSync(`${mapDirectory}/${name}/info.json`))
-    : { author: null, desc: null };
+  try {
+      const metaData = (fs.existsSync(`${mapDirectory}/${name}/info.json`))
+        ? JSON.parse(fs.readFileSync(`${mapDirectory}/${name}/info.json`))
+        : { author: null, desc: null };
+  } catch (error) {
+    // hacky fix attempt at fixing the extremely common problem of "Error invoking remote method 'updatemapsfromdirectory: syntax error: Unexpected string in JSON at position 43" because leth forgot how to json with the Aerial Training Remastered map and blatantly ignored users telling him about it.
+    // that error results in the map loader being softlocked until the user figures out that it's because of aerial training remastered and gets rid of it.
+    console.log("whatever we messed up reading the json of this map give it all null!!!");
+    const metaData = { author: null, desc: null};
+  }
   const { author, desc } = metaData;
   return {
     id: index,

--- a/lib/manageMapFiles.js
+++ b/lib/manageMapFiles.js
@@ -51,7 +51,7 @@ const appBackupPath = path.join(AppData, underpassPreservationName);
 
 const isValidUnderpass = (mapPath) => {
   const { size: fileSize } = fs.statSync(mapPath);
-  if (fileSize >= 2438000 || fileSize <= 2104605) return false;
+  if (fileSize >= 2575186 || fileSize <= 2104605) return false;
   return true;
 };
 


### PR DESCRIPTION
hacky fix attempt at fixing the extremely common problem of "Error invoking remote method 'updatemapsfromdirectory: syntax error: Unexpected string in JSON at position 43" because leth forgot how to json with the Aerial Training Remastered map and blatantly ignored users telling him about it.
that error results in the map loader being softlocked until the user figures out that it's because of aerial training remastered and gets rid of it.
